### PR TITLE
Feature: search for the use of plgx extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - [ ] Automatically look for KeePass portable + Windows store installation files via SMB C$ share.
   - [ ] Automatically check for running KeePass process through Impacket-based command execution.
   - [ ] Multi-thread implementation to avoid bottleneck hosts.
+  - [x] Automatically look for KeePass plugin cache folder.
 - [x] KeePass Trigger Abuse
   - [x] Add and remove triggers from KeePass configuration file via SMB C$ share.
   - [x] Automatically poll for cleartext exports on the remote host.

--- a/keepwn/utils/logging.py
+++ b/keepwn/utils/logging.py
@@ -57,18 +57,11 @@ def print_found_cache(target, folders_list):
     cprint("[", attrs=["bold"], end="")
     cprint(target, "green", attrs=["bold"], end="")
     cprint("]", attrs=["bold"], end=" ")
-    cprint("Found plugin cache folder:", end="\n")
 
     for folder in folders_list:
-        cprint("[", attrs=["bold"], end="")
-        cprint(target, "green", attrs=["bold"], end="")
-        cprint("]", attrs=["bold"], end=" ")
-        cprint("\t", end="")
-        cprint("[", attrs=["bold"], end="")
-        cprint("!", "yellow", attrs=["bold"], end="")
-        cprint("]", attrs=["bold"], end=" ")
-        cprint("'{}'".format(folder), "blue")
-#        cprint("\t\t[*] {}".format(folder), "blue")
+        cprint("Found ", end="")
+        cprint("'{}' ".format(folder), "blue", end="")
+        cprint("(cache folder)", "red")
 
 def print_not_found_cache(target):
     cprint("[", attrs=["bold"], end="")

--- a/keepwn/utils/logging.py
+++ b/keepwn/utils/logging.py
@@ -53,6 +53,30 @@ def print_alert_target(target, string):
     cprint("]", attrs=["bold"], end=" ")
     print(string)
 
+def print_found_cache(target, folders_list):
+    cprint("[", attrs=["bold"], end="")
+    cprint(target, "green", attrs=["bold"], end="")
+    cprint("]", attrs=["bold"], end=" ")
+    cprint("Found plugin cache folder:", end="\n")
+
+    for folder in folders_list:
+        cprint("[", attrs=["bold"], end="")
+        cprint(target, "green", attrs=["bold"], end="")
+        cprint("]", attrs=["bold"], end=" ")
+        cprint("\t", end="")
+        cprint("[", attrs=["bold"], end="")
+        cprint("!", "yellow", attrs=["bold"], end="")
+        cprint("]", attrs=["bold"], end=" ")
+        cprint("'{}'".format(folder), "blue")
+#        cprint("\t\t[*] {}".format(folder), "blue")
+
+def print_not_found_cache(target):
+    cprint("[", attrs=["bold"], end="")
+    cprint(target, "grey", attrs=["bold"], end="")
+    cprint("]", attrs=["bold"], end=" ")
+    cprint("No plugin cache folder found")
+
+
 def print_found_keepass(target, path, last_access_message, highlight_priority):
     cprint("[", attrs=["bold"], end="")
     cprint(target, "green", attrs=["bold"], end="")


### PR DESCRIPTION
A post-exploitation approach exists to load arbitrary DLL from the default cache folder of plgx plugins. The following function is looking for subfolders in the default cache folder. If one subfolder is found, the following message is printed.

![image](https://user-images.githubusercontent.com/37596668/217306204-f5b99be3-2b90-4ccd-ac44-ef416a6acb45.png)
