### PR TITLE
Fixed charsets

### DIFF
--- a/keepwn/core/parse_dump.py
+++ b/keepwn/core/parse_dump.py
@@ -22,7 +22,7 @@ def get_candidates(dump_file): # code taken from @CMEPW: https://github.com/CMEP
             str_len += 1
             i += 1
         elif str_len > 0:
-            if (data[i] >= 0x20) and (data[i] <= 0x7E) and (data[i + 1] == 0x00):
+            if (data[i] >= 0x20) and (data[i] <= 0xFF) and (data[i + 1] == 0x00):
                 candidate = (str_len * b'\xCF\x25') + bytes([data[i], data[i + 1]])
                 if not candidate in candidates:
                     candidates.append(candidate)


### PR DESCRIPTION
Hello, thank you for this tool.

If the password contain some character, for example the character 'Ø', it isn't displayed.

Here is what I did:

1) Set the password of a database as 'TestØ'
2) Enter the password without copying it
3) Create a memory dump (using task manager for example)
4) python3 KeePwn.py parse_dump -d ../KeePass.DMP

With my "patch":
![image](https://github.com/lap1nou/KeePwn/assets/10383569/af6f9eb6-292d-4c1b-93f9-f6f4b820c795)

Without my "patch":
![image](https://github.com/lap1nou/KeePwn/assets/10383569/f7a815a6-fddc-4d9f-8852-afc77bb295c5)

As you can see the last character is missing, this seems to be the same problem fixed by this PR: https://github.com/vdohney/keepass-password-dumper/pull/15