### PR TITLE
Feature : Convert KDBX to John and Hashcat compatible formats

### DIFF
--- a/keepwn/__main__.py
+++ b/keepwn/__main__.py
@@ -1,6 +1,7 @@
 import os
 
 from keepwn.core.parse_dump import parse_dump
+from keepwn.core.convert import convert
 from keepwn.core.plugin import check_plugin, add_plugin, clean_plugin, poll_plugin
 from keepwn.core.search import search
 from keepwn.core.trigger import check_trigger, add_trigger, clean_trigger, poll_trigger
@@ -38,7 +39,8 @@ def main():
             poll_plugin(options)
     if options.mode == 'parse_dump':
         parse_dump(options)
-
+    if options.mode == 'convert':
+        convert(options)
 
 if __name__ == '__main__':
     main()

--- a/keepwn/core/convert.py
+++ b/keepwn/core/convert.py
@@ -1,26 +1,31 @@
-from os import popen
-from keepwn.utils.logging import print_info, print_error
+from keepwn.utils.logging import print_info, print_error, print_success
+from keepwn.utils.keepass2john import process_database
 
 def write_hash(hash, output_file):
     print_info('Writing converted hash in {} file'.format(output_file))
     
-    with open(output_file ,"a") as f:
+    with open(output_file ,"w") as f:
         f.write(hash)
 
+    print_success('Hash written in destination file. Ready to crack.')
+
 def convert(options):
-    cmd = '~/john/run/keepass2john {}'.format(options.database_path)
     if options.output_file is None:
         options.output_file = "keepass.hash"
-
+    
     if options.convert_type == 'john':
         print_info('Converting {} in john format'.format(options.database_path))
-        hash = popen(cmd).read()
+        hash = process_database(options.database_path)
 
     elif options.convert_type == 'hashcat':
         print_info('Converting {} in hashcat format'.format(options.database_path))
-        hash = popen(cmd).read().split(':')[1]
+        hash = process_database(options.database_path).split(':')[1]
     else:
         print_error('Uncorrect convert type, please choose john or hashcat')
 
     if hash is not None:
+        print(hash)
         write_hash(hash, options.output_file)
+    else:
+        print_error('Error during hash extraction. Aborting')
+        exit(0)

--- a/keepwn/core/convert.py
+++ b/keepwn/core/convert.py
@@ -1,0 +1,23 @@
+from os import popen
+from keepwn.utils.logging import print_info, print_error
+
+def write_hash(hash):
+    filename = "keepass.hash"
+    print_info('Writing converted hash in {} file'.format(filename))
+    
+    with open(filename ,"a") as f:
+        f.write(hash)
+
+def convert(convert_type, database_name) -> str:
+    if convert_type == 'john':
+        print_info('Converting {} in john format'.format(database_name))
+        hash = popen('john/run/keepass2john').read()
+
+    elif convert_type == 'hashcat':
+        print_info('Converting {} in hashcat format'.format(database_name))
+        hash = popen('john/run/keepass2john').read().strip(':')[1]
+    else:
+        print_error('Uncorrect convert type, please choose john or hashcat')
+
+    if hash is not None:
+        write_hash(hash)

--- a/keepwn/core/convert.py
+++ b/keepwn/core/convert.py
@@ -1,23 +1,26 @@
 from os import popen
 from keepwn.utils.logging import print_info, print_error
 
-def write_hash(hash):
-    filename = "keepass.hash"
-    print_info('Writing converted hash in {} file'.format(filename))
+def write_hash(hash, output_file):
+    print_info('Writing converted hash in {} file'.format(output_file))
     
-    with open(filename ,"a") as f:
+    with open(output_file ,"a") as f:
         f.write(hash)
 
-def convert(convert_type, database_name) -> str:
-    if convert_type == 'john':
-        print_info('Converting {} in john format'.format(database_name))
-        hash = popen('john/run/keepass2john').read()
+def convert(options):
+    cmd = '~/john/run/keepass2john {}'.format(options.database_path)
+    if options.output_file is None:
+        options.output_file = "keepass.hash"
 
-    elif convert_type == 'hashcat':
-        print_info('Converting {} in hashcat format'.format(database_name))
-        hash = popen('john/run/keepass2john').read().strip(':')[1]
+    if options.convert_type == 'john':
+        print_info('Converting {} in john format'.format(options.database_path))
+        hash = popen(cmd).read()
+
+    elif options.convert_type == 'hashcat':
+        print_info('Converting {} in hashcat format'.format(options.database_path))
+        hash = popen(cmd).read().split(':')[1]
     else:
         print_error('Uncorrect convert type, please choose john or hashcat')
 
     if hash is not None:
-        write_hash(hash)
+        write_hash(hash, options.output_file)

--- a/keepwn/utils/keepass2john.py
+++ b/keepwn/utils/keepass2john.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python3
+
+import os
+import struct
+from binascii import hexlify
+from keepwn.utils.logging import print_error
+
+def process_1x_database(data, databaseName, maxInlineSize=1024):
+    index = 8
+    algorithm = None
+
+    enc_flag = struct.unpack("<L", data[index:index+4])[0]
+    index += 4
+    if (enc_flag & 2 == 2):
+        # AES
+        algorithm = 0
+    elif (enc_flag & 8):
+        # Twofish
+        algorithm = 1
+    else:
+        print_error("Unsupported file encryption!")
+        exit(0)
+
+    # TODO: keyfile processing
+
+    # TODO: database version checking
+    version = hexlify(data[index:index+4]).decode('utf-8')
+    index += 4
+
+    finalRandomseed = hexlify(data[index:index+16])
+    index += 16
+
+    encIV = hexlify(data[index:index+16]).decode('utf-8')
+    index += 16
+
+    numGroups = struct.unpack("<L", data[index:index+4])[0]
+    index += 4
+    numEntries = struct.unpack("<L", data[index:index+4])[0]
+    index += 4
+
+    contentsHash = hexlify(data[index:index+32]).decode('utf-8')
+    index += 32
+
+    transfRandomseed = hexlify(data[index:index+32]).decode('utf-8')
+    index += 32
+
+    keyTransfRounds = struct.unpack("<L", data[index:index+4])[0]
+
+    filesize = len(data)
+    datasize = filesize - 124
+
+    if (filesize + datasize) < maxInlineSize:
+        dataBuffer = hexlify(data[124:]).decode('utf-8')
+        end = "*1*%ld*%s" % (datasize, hexlify(dataBuffer))
+    else:
+        end = "0*%s" % (databaseName)
+
+    return "%s:$keepass$*1*%s*%s*%s*%s*%s*%s*%s" % (databaseName, keyTransfRounds, algorithm, finalRandomseed, transfRandomseed, encIV, contentsHash, end)
+
+def process_2x_database(data, databaseName):
+
+    index = 12
+    endReached = False
+
+    while not endReached:
+
+        btFieldID = struct.unpack("B", data[index:index+1])[0]
+        index += 1
+        uSize = struct.unpack("H", data[index:index+2])[0]
+        index += 2
+
+        if btFieldID == 0:
+            endReached = True
+
+        if btFieldID == 4:
+            masterSeed = hexlify(data[index:index+uSize]).decode('utf-8')
+
+        if btFieldID == 5:
+            transformSeed = hexlify(data[index:index+uSize]).decode('utf-8')
+
+        if btFieldID == 6:
+            transformRounds = struct.unpack("H", data[index:index+2])[0]
+
+        if btFieldID == 7:
+            initializationVectors = hexlify(data[index:index+uSize]).decode('utf-8')
+
+        if btFieldID == 9:
+            expectedStartBytes = hexlify(data[index:index+uSize]).decode('utf-8')
+
+        index += uSize
+
+    dataStartOffset = index
+    firstEncryptedBytes = hexlify(data[index:index+32]).decode('utf-8')
+
+    return "%s:$keepass$*2*%s*%s*%s*%s*%s*%s*%s" % (databaseName, transformRounds, dataStartOffset, masterSeed, transformSeed, initializationVectors, expectedStartBytes, firstEncryptedBytes)
+
+def process_database(filename):
+
+    f = open(filename, 'rb')
+    data = f.read()
+    f.close()
+
+    base = os.path.basename(filename)
+    databaseName = os.path.splitext(base)[0]
+
+    fileSignature = hexlify(data[0:8])
+
+    if fileSignature == b'03d9a29a67fb4bb5':
+        # "2.X"
+        hash = process_2x_database(data, databaseName)
+
+    elif fileSignature == b'03d9a29a66fb4bb5':
+        # "2.X pre release"
+        hash = process_2x_database(data, databaseName)
+
+    elif fileSignature == b'03d9a29a65fb4bb5':
+        # "1.X"
+        hash = process_1x_database(data, databaseName)
+    else:
+        print_error("ERROR: KeePass signature unrecognized")
+
+    return hash

--- a/keepwn/utils/parser.py
+++ b/keepwn/utils/parser.py
@@ -125,7 +125,8 @@ def parse_args():
     #convert subparser
     convert_parser = argparse.ArgumentParser(add_help=False)
     convert_parser.add_argument("-ct", "--convert_type", default=None, help="Conversion type (John or Hashcat)")
-    convert_parser.add_argument("-db", "--database_name", default=None, help="KDBX database to convert in hash")
+    convert_parser.add_argument("-db", "--database_path", default=None, help="KDBX database to convert in hash")
+    convert_parser.add_argument("-o", "--output_file", default=None, help="Output hash file")
 
     # adding the subparsers to the main parser
     subparsers = main_parser.add_subparsers(help="Mode", dest="mode")

--- a/keepwn/utils/parser.py
+++ b/keepwn/utils/parser.py
@@ -122,6 +122,10 @@ def parse_args():
     parse_dump_parser.add_argument("-d", "--dump_file", default=None, help="Path of the memory dump to parse")
     parse_dump_parser.add_argument("-b", "--bruteforce", default=None, help="Database to bruteforce")
 
+    #convert subparser
+    convert_parser = argparse.ArgumentParser(add_help=False)
+    convert_parser.add_argument("-ct", "--convert_type", default=None, help="Conversion type (John or Hashcat)")
+    convert_parser.add_argument("-db", "--database_name", default=None, help="KDBX database to convert in hash")
 
     # adding the subparsers to the main parser
     subparsers = main_parser.add_subparsers(help="Mode", dest="mode")
@@ -139,6 +143,7 @@ def parse_args():
     plugin_remove_subparser = plugin_subparsers.add_parser("remove", parents=[plugin_remove_parser])
     plugin_poll_subparser = plugin_subparsers.add_parser("poll", parents=[plugin_poll_parser])
     parse_dump_subparser = subparsers.add_parser("parse_dump", parents=[parse_dump_parser], help="Find the master password in memory dump (CVE-2023-32784)")
+    convert_subparser = subparsers.add_parser("convert", parents=[convert_parser], help="Convert KDBX to John and Hashcat compatible formats (including KDBX 4)")
 
     options = main_parser.parse_args()
 
@@ -193,6 +198,10 @@ def parse_args():
 
     if options.mode == 'parse_dump' and len(sys.argv) == 2:
         parse_dump_subparser.print_help()
+        exit(0)
+
+    if options.mode == 'convert' and len(sys.argv) == 2:
+        convert_subparser.print_help()
         exit(0)
 
     return options


### PR DESCRIPTION
Hi Orange,

I just quickly coded the feature to convert KDBX to John and Hashcat compatible formats. Since KDBX 4 hash extraction is not yet possible, I was not able to add this part. I'm not a developer, just a cybersecurity student who likes to participate in the projects and tools he uses, so there will probably be some changes to make (getting the keepass2john binary installed in /usr/local/bin like the other scripts downloaded during installation for example). Merci Orange Cyberdéfense pour ce précieux outil, contactez-moi si vous avez besoin d'un alternant :)